### PR TITLE
Changed settings strategy for allow_list to use Windower's settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+data/settings.xml


### PR DESCRIPTION
allow_list is now saved in windower's settings as a comma-separated list, extracted at load and login, and the commands to add/remove allow words has been updated to support removing the exact word instead of by index.